### PR TITLE
Add support for subcommands

### DIFF
--- a/radicli/tests/test_cli.py
+++ b/radicli/tests/test_cli.py
@@ -328,3 +328,35 @@ def test_cli_subcommands_child_extra():
     sys.argv = ["", "parent", "child", *args_child]
     cli.run()
     assert ran_child
+
+
+def test_cli_subcommands_no_parent():
+    args_child1 = ["--a", "hey", "--b", "2", "--c"]
+    args_child2 = ["yo", "--y", "pasta"]
+    ran_child1 = False
+    ran_child2 = False
+
+    cli = Radicli("test")
+
+    @cli.subcommand("parent", "child1", a=Arg("--a"), b=Arg("--b"), c=Arg("--c"))
+    def child1(a: str, b: int, c: bool):
+        assert a == "hey"
+        assert b == 2
+        assert c
+        nonlocal ran_child1
+        ran_child1 = True
+
+    @cli.subcommand("parent", "child2", x=Arg(), y=Arg("--y"))
+    def child2(x: str, y: Literal["pizza", "pasta"]):
+        assert x == "yo"
+        assert y == "pasta"
+        nonlocal ran_child2
+        ran_child2 = True
+
+    sys.argv = ["", "parent", "child1", *args_child1]
+    cli.run()
+    assert ran_child1
+
+    sys.argv = ["", "parent", "child2", *args_child2]
+    cli.run()
+    assert ran_child2

--- a/radicli/util.py
+++ b/radicli/util.py
@@ -18,6 +18,7 @@ class UnsupportedTypeError(Exception):
         self.arg = arg
         self.annot = annot
         self.message = f"Unsupported type for '{self.arg}': {self.annot}"
+        super().__init__(self.message)
 
 
 class CommandNotFoundError(Exception):
@@ -27,6 +28,7 @@ class CommandNotFoundError(Exception):
         self.message = (
             f"Can't find command '{self.name}'. Available: {', '.join(self.options)}"
         )
+        super().__init__(self.message)
 
 
 class InvalidArgumentError(Exception):
@@ -34,6 +36,7 @@ class InvalidArgumentError(Exception):
         self.id = arg_id
         self.msg = message
         self.message = f"Invalid argument '{self.id}': {self.msg}"
+        super().__init__(self.message)
 
 
 @dataclass


### PR DESCRIPTION
Currently only supports one level of nesting, due to how `argparse` works. Introduces additional decorators `subcommand` and `subcommand_with_extra` that work with namespaces.

## Example

```python
from typing import List, Literal
from radicli import Radicli, Arg

cli = Radicli("test", prog="python -m spacy", help="This is a test")


@cli.command(
    "hello",
    a=Arg(help="This is is any text"),
    b=Arg("--b", "-B", help="This is a number"),
    c=Arg("--c", help="This is a list of things"),
    d=Arg("--d", help="Pick a food item"),
    e=Arg("--e", "-E", help="Yes or no"),
)
def hello(
    a="hello",
    *,
    c: List[str],
    d: Literal["pizza", "pasta"],
    e: bool,
    b: int = 100,
):
    """Print some stuff"""
    print(a, b, c, d, e)


@cli.subcommand_with_extra(
    "hello",
    "world",
    a=Arg("--a", help="Subcommand command"),
    d=Arg("--d", help="Subcommand command 2"),
)
def hello_world(a: int, d: int, _extra):
    """Hello world"""
    print(a, d, _extra)


@cli.subcommand(
    "hello",
    "you",
    a=Arg("--a", help="Subcommand command"),
    d=Arg("--d", help="Subcommand command 2"),
)
def hello_you(a: str, d: str):
    """Hello you"""
    print("you", a, d)


if __name__ == "__main__":
    cli.run()
```