### PR TITLE
Swap TypeVars to use `typing.NewType` and type aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,13 +163,13 @@ $ python test.py process en_core_web_sm --text Hello world!
 Hello world! ['INTJ', 'NOUN', 'PUNCT']
 ```
 
-If you want to alias an existing type to add custom handling for it, you can use a `TypeVar`. This is also how the built-in [`Path` converters](#custom-types-and-converters) are implemented. In help messages, the type the variable is bound to will be displayed together with the custom name.
+If you want to alias an existing type to add custom handling for it, you can create a `NewType`. This is also how the built-in [`Path` converters](#custom-types-and-converters) are implemented. In help messages, the type it is based on will be displayed together with the custom name.
 
 ```python
-from typing import TypeVar
+from typing import NewType
 from pathlib import Path
 
-ExistingPath = TypeVar("ExistingPath", bound=Path)
+ExistingPath = NewType("ExistingPath", Path)
 
 def convert_existing_path(path_str: str) -> Path:
     path = Path(path_str)

--- a/radicli/__init__.py
+++ b/radicli/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Tuple
+from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Tuple, cast
 import sys
 from dataclasses import dataclass
 from inspect import signature
@@ -6,7 +6,7 @@ from inspect import signature
 from .parser import ArgumentParser, HelpFormatter
 from .util import Arg, ArgparseArg, get_arg, join_strings, format_type, format_table
 from .util import format_arg_help, SimpleFrozenDict, CommandNotFoundError
-from .util import CliParserError, DEFAULT_CONVERTERS
+from .util import CliParserError, ConvertersType, DEFAULT_CONVERTERS
 
 # Make available for import
 from .util import ExistingPath, ExistingFilePath, ExistingDirPath  # noqa: F401
@@ -34,7 +34,7 @@ class Command:
 class Radicli:
     prog: Optional[str]
     help: Optional[str]
-    converters: Dict[Type, Callable[[str], Any]]
+    converters: ConvertersType
     extra_key: str
     commands: Dict[str, Command]
     subcommands: Dict[str, Dict[str, Command]]
@@ -46,7 +46,7 @@ class Radicli:
         *,
         prog: Optional[str] = None,
         help: Optional[str] = None,
-        converters: Dict[Type, Callable[[str], Any]] = SimpleFrozenDict(),
+        converters: ConvertersType = SimpleFrozenDict(),
         extra_key: str = "_extra",
     ) -> None:
         """Initialize the CLI and create the registry."""
@@ -251,7 +251,7 @@ class Radicli:
             return values
         if sub_key not in subparsers:
             raise CliParserError(f"invalid subcommand: '{sub_key}'")
-        subparser, subcmd = subparsers[sub_key]
+        subparser, subcmd = subparsers[cast(str, sub_key)]
         sub_namespace, sub_extra = subparser.parse_known_args(args[1:])
         sub_values = {**vars(sub_namespace), self.extra_key: sub_extra}
         sub_values = self._handle_extra(p, sub_values, subcmd.allow_extra)

--- a/radicli/parser.py
+++ b/radicli/parser.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, NoReturn
 import argparse
 import sys
 
@@ -6,7 +6,7 @@ from .util import format_arg_help, CliParserError
 
 
 class ArgumentParser(argparse.ArgumentParser):
-    def error(self, message: str) -> None:
+    def error(self, message: str) -> NoReturn:
         raise CliParserError(message)
 
     # Overriding this internal function so we can have more control over how

--- a/radicli/util.py
+++ b/radicli/util.py
@@ -4,6 +4,7 @@ from enum import Enum
 from dataclasses import dataclass
 from pathlib import Path
 import inspect
+import argparse
 
 # We need this Iterable type, which is the type origin of types.Iterable
 try:
@@ -13,6 +14,8 @@ except ImportError:
 
 
 BASE_TYPES = [str, int, float, Path]
+ConverterType = Callable[[str], Any]
+ConvertersType = Dict[Union[Type, object], ConverterType]
 
 
 class CliParserError(SystemExit):
@@ -54,7 +57,7 @@ class Arg:
     option: Optional[str] = None
     short: Optional[str] = None
     help: Optional[str] = None
-    converter: Optional[Callable[[str], Any]] = None
+    converter: Optional[ConverterType] = None
     count: bool = False
 
 
@@ -68,18 +71,22 @@ class ArgparseArg:
     default: Any = ...
     # We modify the help to add types so we store it twice to store old and new
     help: Optional[str] = None
-    action: Optional[str] = None
+    action: Optional[Union[str, Type[argparse.Action]]] = None
     choices: Optional[Union[List[str], List[Enum]]] = None
     has_converter: bool = False
 
     def to_argparse(self) -> Tuple[List[str], Dict[str, Any]]:
         """Helper method to generate args and kwargs for Parser.add_argument."""
-        args = []
+        args: List[str] = []
         if self.arg.option:
             args.append(self.arg.option)
         if self.arg.short:
             args.append(self.arg.short)
-        kwargs = {"dest": self.id, "action": self.action, "help": self.help}
+        kwargs: Dict[str, Any] = {
+            "dest": self.id,
+            "action": self.action,
+            "help": self.help,
+        }
         if self.default is not ...:
             kwargs["default"] = self.default
         # Support defaults for positional arguments
@@ -99,7 +106,7 @@ def get_arg(
     param_type: Any,
     *,
     default: Optional[Any] = ...,
-    get_converter: Optional[Callable[[Type], Optional[Callable[[str], Any]]]] = None,
+    get_converter: Optional[Callable[[Type], Optional[ConverterType]]] = None,
     skip_resolve: bool = False,
 ) -> ArgparseArg:
     """Generate an argument to add to argparse and interpret types if possible."""
@@ -271,7 +278,7 @@ ExistingDirPathOrDash = Union[ExistingDirPath, Literal["-"]]
 PathOrDash = Union[Path, Literal["-"]]
 
 
-DEFAULT_CONVERTERS: Dict[Type, Callable[[str], Any]] = {
+DEFAULT_CONVERTERS: ConvertersType = {
     ExistingPath: convert_existing_path,
     ExistingFilePath: convert_existing_file_path,
     ExistingDirPath: convert_existing_dir_path,

--- a/radicli/util.py
+++ b/radicli/util.py
@@ -185,7 +185,7 @@ def find_base_type(
 def format_type(arg_type: Any) -> str:
     """Get a pretty-printed string for a type."""
     # Nicer formatting for our own TypeVars
-    if isinstance(arg_type, type(NewType)) and arg_type.__supertype__:  # type: ignore
+    if isinstance(arg_type, type(NewType)) and getattr(arg_type, "__supertype__"):  # type: ignore
         return f"{arg_type.__name__} ({format_type(arg_type.__supertype__)})"  # type: ignore
     if hasattr(arg_type, "__name__"):
         return arg_type.__name__

--- a/radicli/util.py
+++ b/radicli/util.py
@@ -260,20 +260,6 @@ def convert_path_or_dash(path_str: str) -> Union[Path, str]:
 
 
 # Custom path types for custom converters
-# ExistingPath = TypeVar("ExistingPath", bound=Path)
-# ExistingFilePath = TypeVar("ExistingFilePath", bound=Path)
-# ExistingDirPath = TypeVar("ExistingDirPath", bound=Path)
-# ExistingPathOrDash = TypeVar("ExistingPathOrDash", bound=Union[Path, Literal["-"]])
-# ExistingFilePathOrDash = TypeVar(
-#     "ExistingFilePathOrDash", bound=Union[Path, Literal["-"]]
-# )
-# ExistingDirPathOrDash = TypeVar(
-#     "ExistingDirPathOrDash", bound=Union[Path, Literal["-"]]
-# )
-# PathOrDash = TypeVar("PathOrDash", bound=Union[Path, Literal["-"]])
-
-
-# Custom path types for custom converters
 ExistingPath = NewType("ExistingPath", Path)
 ExistingFilePath = NewType("ExistingFilePath", Path)
 ExistingDirPath = NewType("ExistingDirPath", Path)

--- a/radicli/util.py
+++ b/radicli/util.py
@@ -280,7 +280,7 @@ ExistingDirPath = NewType("ExistingDirPath", Path)
 
 ExistingPathOrDash = Union[ExistingPath, Literal["-"]]
 ExistingFilePathOrDash = Union[ExistingFilePath, Literal["-"]]
-ExistingDirPathOrDash = Union[ExistingFilePath, Literal["-"]]
+ExistingDirPathOrDash = Union[ExistingDirPath, Literal["-"]]
 PathOrDash = Union[Path, Literal["-"]]
 
 

--- a/radicli/util.py
+++ b/radicli/util.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Iterable, Type, Union, Optional, Dict, Tuple, List, Literal, TypeVar, NewType, get_args, get_origin
+from typing import Any, Callable, Iterable, Type, Union, Optional, Dict, Tuple
+from typing import List, Literal, NewType, get_args, get_origin
 from enum import Enum
 from dataclasses import dataclass
 from pathlib import Path
@@ -184,8 +185,8 @@ def find_base_type(
 def format_type(arg_type: Any) -> str:
     """Get a pretty-printed string for a type."""
     # Nicer formatting for our own TypeVars
-    if isinstance(arg_type, TypeVar) and arg_type.__bound__:
-        return f"{arg_type.__name__} ({format_type(arg_type.__bound__)})"
+    if isinstance(arg_type, type(NewType)) and arg_type.__supertype__:  # type: ignore
+        return f"{arg_type.__name__} ({format_type(arg_type.__supertype__)})"  # type: ignore
     if hasattr(arg_type, "__name__"):
         return arg_type.__name__
     type_str = str(arg_type)

--- a/radicli/util.py
+++ b/radicli/util.py
@@ -199,7 +199,7 @@ def find_base_type(
 def format_type(arg_type: Any) -> str:
     """Get a pretty-printed string for a type."""
     # Nicer formatting for our own TypeVars
-    if isinstance(arg_type, type(NewType)) and getattr(arg_type, "__supertype__"):  # type: ignore
+    if isinstance(arg_type, type(NewType)) and hasattr(arg_type, "__supertype__"):  # type: ignore
         return f"{arg_type.__name__} ({format_type(arg_type.__supertype__)})"  # type: ignore
     if hasattr(arg_type, "__name__"):
         return arg_type.__name__

--- a/radicli/util.py
+++ b/radicli/util.py
@@ -1,5 +1,4 @@
-from typing import Any, Callable, Iterable, Type, Union, Optional, Dict, Tuple
-from typing import List, Literal, TypeVar, get_origin, get_args
+from typing import Any, Callable, Iterable, Type, Union, Optional, Dict, Tuple, List, Literal, TypeVar, NewType, get_args, get_origin
 from enum import Enum
 from dataclasses import dataclass
 from pathlib import Path
@@ -261,17 +260,29 @@ def convert_path_or_dash(path_str: str) -> Union[Path, str]:
 
 
 # Custom path types for custom converters
-ExistingPath = TypeVar("ExistingPath", bound=Path)
-ExistingFilePath = TypeVar("ExistingFilePath", bound=Path)
-ExistingDirPath = TypeVar("ExistingDirPath", bound=Path)
-ExistingPathOrDash = TypeVar("ExistingPathOrDash", bound=Union[Path, Literal["-"]])
-ExistingFilePathOrDash = TypeVar(
-    "ExistingFilePathOrDash", bound=Union[Path, Literal["-"]]
-)
-ExistingDirPathOrDash = TypeVar(
-    "ExistingDirPathOrDash", bound=Union[Path, Literal["-"]]
-)
-PathOrDash = TypeVar("PathOrDash", bound=Union[Path, Literal["-"]])
+# ExistingPath = TypeVar("ExistingPath", bound=Path)
+# ExistingFilePath = TypeVar("ExistingFilePath", bound=Path)
+# ExistingDirPath = TypeVar("ExistingDirPath", bound=Path)
+# ExistingPathOrDash = TypeVar("ExistingPathOrDash", bound=Union[Path, Literal["-"]])
+# ExistingFilePathOrDash = TypeVar(
+#     "ExistingFilePathOrDash", bound=Union[Path, Literal["-"]]
+# )
+# ExistingDirPathOrDash = TypeVar(
+#     "ExistingDirPathOrDash", bound=Union[Path, Literal["-"]]
+# )
+# PathOrDash = TypeVar("PathOrDash", bound=Union[Path, Literal["-"]])
+
+
+# Custom path types for custom converters
+ExistingPath = NewType("ExistingPath", Path)
+ExistingFilePath = NewType("ExistingFilePath", Path)
+ExistingDirPath = NewType("ExistingDirPath", Path)
+
+ExistingPathOrDash = Union[ExistingPath, Literal["-"]]
+ExistingFilePathOrDash = Union[ExistingFilePath, Literal["-"]]
+ExistingDirPathOrDash = Union[ExistingFilePath, Literal["-"]]
+PathOrDash = Union[Path, Literal["-"]]
+
 
 DEFAULT_CONVERTERS: Dict[Type, Callable[[str], Any]] = {
     ExistingPath: convert_existing_path,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 0.0.2
+version = 0.0.3
 description = Radically lightweight command-line interfaces
 url = https://github.com/explosion/radicli
 author = Explosion


### PR DESCRIPTION
TypeVar isn't supported by itself in a function definition so you get a fun little error (yellow line in basic pyright checks in VScode). I think really these extra path types are great use cases for `typing.NewType` which tells the typechecker this type is a constrained version of the bound type. 

More info here: https://docs.python.org/3/library/typing.html#newtype

Then the Union types (e.g. `ExistingPathOrDash`) can just be type aliases utilizing these new path types and the type checker is happy again