### PR TITLE
Feature suggestion: Error maps

### DIFF
--- a/radicli/util.py
+++ b/radicli/util.py
@@ -1,10 +1,11 @@
 from typing import Any, Callable, Iterable, Type, Union, Optional, Dict, Tuple
-from typing import List, Literal, NewType, get_args, get_origin
+from typing import List, Literal, NewType, get_args, get_origin, Set
 from enum import Enum
 from dataclasses import dataclass
 from pathlib import Path
 import inspect
 import argparse
+import sys
 
 # We need this Iterable type, which is the type origin of types.Iterable
 try:
@@ -16,6 +17,8 @@ except ImportError:
 BASE_TYPES = [str, int, float, Path]
 ConverterType = Callable[[str], Any]
 ConvertersType = Dict[Union[Type, object], ConverterType]
+ErrorHandlerType = Callable[[Exception], Optional[int]]
+ErrorHandlersType = Dict[Type[Exception], ErrorHandlerType]
 
 
 class CliParserError(SystemExit):

--- a/radicli/util.py
+++ b/radicli/util.py
@@ -1,11 +1,10 @@
 from typing import Any, Callable, Iterable, Type, Union, Optional, Dict, Tuple
-from typing import List, Literal, NewType, get_args, get_origin, Set
+from typing import List, Literal, NewType, get_args, get_origin
 from enum import Enum
 from dataclasses import dataclass
 from pathlib import Path
 import inspect
 import argparse
-import sys
 
 # We need this Iterable type, which is the type origin of types.Iterable
 try:
@@ -247,6 +246,19 @@ def format_arg_help(text: Optional[str], max_width: int = 70) -> str:
     d = (text or "").strip()[:max_width]
     end = "." if "." in d or len(text or "") <= max_width else "..."
     return (d.rsplit(".", 1)[0] if "." in d else d) + end
+
+
+def expand_error_subclasses(
+    errors: Dict[Type[Exception], ErrorHandlerType]
+) -> Dict[Type[Exception], ErrorHandlerType]:
+    """Map subclasses of errors to their parent's handler."""
+    output = {}
+    for err, callback in errors.items():
+        if hasattr(err, "__subclasses__"):
+            for subclass in err.__subclasses__():
+                output[subclass] = callback
+        output[err] = callback
+    return output
 
 
 def convert_existing_path(path_str: str) -> Path:


### PR DESCRIPTION
We often want to `sys.exit(1)` with a well-formatted message for expected errors when a function is invoked via the CLI. However, if the error-case is unexpected or the function was not invoked by the CLI, we generally don't want to do that.

I suggest supporting mappings within Radicli that are keyed by specific exception types. If the exception or a subclass of it is raised, Radicli will catch the exception and invoke the handler. If the handler returns an integer value, Radicli will call `sys.exit()`. If the handler returns `None`, execution will continue.

So for instance, instead of writing something like this:

```
def my_helper_function(my_arg: str):
    if my_arg_is_invalid(my_arg):
        print(f"Invalid argument {my_arg} -- it's somehow bad")
        sys.exit(1)
```

We would have something like this:

```
def my_helper_function(my_arg: str):
    if my_arg_is_invalid(my_arg):
        raise MyCustomError(f"Invalid argument {my_arg} -- it's somehow bad")

def print_error(e):
    print(e)
    return 1

cli = Radicli(errors={MyCustomError: print_error})
```

I've left it at a single error mapping on the whole object for the draft, but I think we'd want to be able to define the errors alongside the commands, perhaps with a `__radicli_errors__` keyword argument to the `Radicli.command` method. Alternatively we could have a separate method that takes the name of the command and the error mapping. I think a keyword argument on `Radicli.command` is better though, so long as it's prefixed to prevent clashes with actual keyword args.

A simple usage pattern would be to have a single error type, representing the types you would have been tempted to write `sys.exit()` in a helper. You'd simply raise your error type instead, which gets translated. This at least ensures that your function doesn't call `sys.exit` in non-CLI invocation.

Program authors could also write error handlers which make the traceback available, perhaps by raising the error if some environment variable is set, or perhaps by just logging the traceback somewhere where it will be accessible.
