### PR TITLE
Tidy up internal methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,14 @@ Internal representation of a CLI command. Can be accessed via `Radicli.commands`
 
 Create a command from a function and its argument annotations and use the type hints and defaults defined in the function to generate the arguments. This is what happens under the hood in the command decorators and it can be used if you need to construct a `Command` manually.
 
+```python
+def hello(name: str, age: int):
+    print(f"Hello {name} ({age})!")
+
+args = {"name": Arg(), "age": Arg("--age", help="Your age")}
+command = Command.from_function("hello", args, hello)
+```
+
 | Argument      | Type                               | Description                                                                                                 |
 | ------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | `name`        | `str`                              | The name of the command.                                                                                    |
@@ -493,6 +501,23 @@ if __name__ == "__main__":
 | Argument | Type                  | Description                                                                               |
 | -------- | --------------------- | ----------------------------------------------------------------------------------------- |
 | `args`   | `Optional[List[str]]` | Optional command to pass in. Will be read from `sys.argv` if not set (standard use case). |
+
+#### <kbd>method</kbd> `Radicli.parse`
+
+Parse a list of arguments for a given command. Typically internals, but can also be used for testing.
+
+```python
+command = cli.commands["hello"]
+values = cli.parse(["Alex", "--age", "35"], command)
+command.func(**values)
+```
+
+| Argument      | Type                 | Description                                                                                  |
+| ------------- | -------------------- | -------------------------------------------------------------------------------------------- |
+| `args`        | `List[str]`          | The string arguments, e.g. what's received from the command line.                            |
+| `command`     | `Command`            | The command.                                                                                 |
+| `subcommands` | `Dict[str, Command]` | Subcommands of the parent command, if available, keyed by subcommand name. Defaults to `{}`. |
+| **RETURNS**   | `Dict[str, Any]`     | The parsed values keyed by argument name that can be passed to the command function.         |
 
 #### <kbd>method</kbd> `Radicli.to_static`
 

--- a/radicli/tests/test_parser.py
+++ b/radicli/tests/test_parser.py
@@ -2,7 +2,7 @@ from typing import List, Iterable, Optional, Union, Literal, Dict, Any
 from enum import Enum
 import pytest
 import argparse
-from radicli import Radicli, Arg
+from radicli import Radicli, Arg, Command
 from radicli.util import get_arg, UnsupportedTypeError, CliParserError
 
 
@@ -177,7 +177,8 @@ BAD_TEST_CASES = [
 )
 def test_parser_good(args, arg_info, expected):
     cli = Radicli()
-    assert cli.parse(args, arg_info) == expected
+    cmd = Command(name="test", func=lambda: None, args=arg_info)
+    assert cli.parse(args, cmd) == expected
 
 
 @pytest.mark.parametrize(
@@ -186,7 +187,8 @@ def test_parser_good(args, arg_info, expected):
 )
 def test_parser_good_with_extra(args, arg_info, expected):
     cli = Radicli(extra_key=EXTRA_KEY)
-    assert cli.parse(args, arg_info, allow_extra=True) == expected
+    cmd = Command(name="test", func=lambda: None, args=arg_info, allow_extra=True)
+    assert cli.parse(args, cmd) == expected
 
 
 @pytest.mark.parametrize(
@@ -197,4 +199,5 @@ def test_parser_bad(args, get_arg_args, expected_error):
     cli = Radicli()
     with pytest.raises(expected_error):
         arg_info = [get_arg(*args) for args in get_arg_args]
-        cli.parse(args, arg_info)
+        cmd = Command(name="test", func=lambda: None, args=arg_info)
+        cli.parse(args, cmd)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 0.0.11
+version = 0.0.12
 description = Radically lightweight command-line interfaces
 url = https://github.com/explosion/radicli
 author = Explosion


### PR DESCRIPTION
Make `Radicli.parse` take `Command` objects instead of arguments and additional kwargs.