### PR TITLE
Allow partial parsing of arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,12 +512,13 @@ values = cli.parse(["Alex", "--age", "35"], command)
 command.func(**values)
 ```
 
-| Argument      | Type                 | Description                                                                                  |
-| ------------- | -------------------- | -------------------------------------------------------------------------------------------- |
-| `args`        | `List[str]`          | The string arguments, e.g. what's received from the command line.                            |
-| `command`     | `Command`            | The command.                                                                                 |
-| `subcommands` | `Dict[str, Command]` | Subcommands of the parent command, if available, keyed by subcommand name. Defaults to `{}`. |
-| **RETURNS**   | `Dict[str, Any]`     | The parsed values keyed by argument name that can be passed to the command function.         |
+| Argument        | Type                 | Description                                                                                                            |
+| --------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `args`          | `List[str]`          | The string arguments, e.g. what's received from the command line.                                                      |
+| `command`       | `Command`            | The command.                                                                                                           |
+| `subcommands`   | `Dict[str, Command]` | Subcommands of the parent command, if available, keyed by subcommand name. Defaults to `{}`.                           |
+| `allow_partial` | `bool`               | Allow partial parsing and still return the parsed values, even if required arguments are missing. Defaults to `False`. |
+| **RETURNS**     | `Dict[str, Any]`     | The parsed values keyed by argument name that can be passed to the command function.                                   |
 
 #### <kbd>method</kbd> `Radicli.to_static`
 

--- a/radicli/tests/test_parser.py
+++ b/radicli/tests/test_parser.py
@@ -133,6 +133,14 @@ GOOD_WITH_EXTRA_TEST_CASES = [
     ),
 ]
 
+GOOD_PARTIAL_TEST_CASES = [
+    (
+        ["--a", "1"],
+        [get_arg("a", Arg("--a"), str), get_arg("b", Arg("--b"), int)],
+        {"a": "1"},
+    ),
+]
+
 BAD_TEST_CASES = [
     # Unsupported types
     (
@@ -189,6 +197,16 @@ def test_parser_good_with_extra(args, arg_info, expected):
     cli = Radicli(extra_key=EXTRA_KEY)
     cmd = Command(name="test", func=lambda: None, args=arg_info, allow_extra=True)
     assert cli.parse(args, cmd) == expected
+
+
+@pytest.mark.parametrize(
+    "args,arg_info,expected",
+    GOOD_PARTIAL_TEST_CASES,
+)
+def test_parser_good_partial(args, arg_info, expected):
+    cli = Radicli()
+    cmd = Command(name="test", func=lambda: None, args=arg_info)
+    assert cli.parse(args, cmd, allow_partial=True) == expected
 
 
 @pytest.mark.parametrize(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 0.0.13
+version = 0.0.14
 description = Radically lightweight command-line interfaces
 url = https://github.com/explosion/radicli
 author = Explosion


### PR DESCRIPTION
Adds `allow_partial` keyword argument to `Radicli.parse`.