### PR TITLE
Add support for deserializing types from static data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-.env/
+.env*/
 env/
 build/
 develop-eggs/

--- a/README.md
+++ b/README.md
@@ -566,11 +566,12 @@ Load the static CLI from a JSON file generated with `Radicli.to_static`.
 static = StaticRadicli.load("./static.json")
 ```
 
-| Argument    | Type               | Description                                                                                                                                                                  |
-| ----------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `file_path` | `Union[str, Path]` | The JSON file to load.                                                                                                                                                       |
-| `disable`   | `bool`             | Whether to disable static parsing. Can be useful during development. Defaults to `False`.                                                                                    |
-| `debug`     | `bool`             | Enable debugging mode and print an additional start and optional end marker (if the static CLI didn't exit before) to indicate that the static CLI ran. Defaults to `False`. |
+| Argument           | Type                 | Description                                                                                                                                                                                                      |
+| ------------------ | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `file_path`        | `Union[str, Path]`   | The JSON file to load.                                                                                                                                                                                           |
+| `disable`          | `bool`               | Whether to disable static parsing. Can be useful during development. Defaults to `False`.                                                                                                                        |
+| `debug`            | `bool`               | Enable debugging mode and print an additional start and optional end marker (if the static CLI didn't exit before) to indicate that the static CLI ran. Defaults to `False`.                                     |
+| `deserialize_type` | `Optional[Callable]` | Optional callback to deserialize custom argument types. Is called on unknown types and will receive the string name of the type, e.g. `"UUID"`, and should return a callable type, converter function or `None`. |
 
 #### <kbd>method</kbd> `StaticRadicli.__init__`
 
@@ -581,11 +582,12 @@ data = cli.to_static_json()
 static = StaticRadicli(data)
 ```
 
-| Argument  | Type             | Description                                                                                                                                                                  |
-| --------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `data`    | `Dict[str, Any]` | The static data.                                                                                                                                                             |
-| `disable` | `bool`           | Whether to disable static parsing. Can be useful during development. Defaults to `False`.                                                                                    |
-| `debug`   | `bool`           | Enable debugging mode and print an additional start and optional end marker (if the static CLI didn't exit before) to indicate that the static CLI ran. Defaults to `False`. |
+| Argument           | Type                 | Description                                                                                                                                                                                                      |
+| ------------------ | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `data`             | `Dict[str, Any]`     | The static data.                                                                                                                                                                                                 |
+| `disable`          | `bool`               | Whether to disable static parsing. Can be useful during development. Defaults to `False`.                                                                                                                        |
+| `debug`            | `bool`               | Enable debugging mode and print an additional start and optional end marker (if the static CLI didn't exit before) to indicate that the static CLI ran. Defaults to `False`.                                     |
+| `deserialize_type` | `Optional[Callable]` | Optional callback to deserialize custom argument types. Is called on unknown types and will receive the string name of the type, e.g. `"UUID"`, and should return a callable type, converter function or `None`. |
 
 #### <kbd>method</kbd> `StaticRadicli.run`
 

--- a/README.md
+++ b/README.md
@@ -566,12 +566,12 @@ Load the static CLI from a JSON file generated with `Radicli.to_static`.
 static = StaticRadicli.load("./static.json")
 ```
 
-| Argument           | Type                 | Description                                                                                                                                                                                                      |
-| ------------------ | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `file_path`        | `Union[str, Path]`   | The JSON file to load.                                                                                                                                                                                           |
-| `disable`          | `bool`               | Whether to disable static parsing. Can be useful during development. Defaults to `False`.                                                                                                                        |
-| `debug`            | `bool`               | Enable debugging mode and print an additional start and optional end marker (if the static CLI didn't exit before) to indicate that the static CLI ran. Defaults to `False`.                                     |
-| `deserialize_type` | `Optional[Callable]` | Optional callback to deserialize custom argument types. Is called on unknown types and will receive the string name of the type, e.g. `"UUID"`, and should return a callable type, converter function or `None`. |
+| Argument     | Type                               | Description                                                                                                                                                                  |
+| ------------ | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `file_path`  | `Union[str, Path]`                 | The JSON file to load.                                                                                                                                                       |
+| `disable`    | `bool`                             | Whether to disable static parsing. Can be useful during development. Defaults to `False`.                                                                                    |
+| `debug`      | `bool`                             | Enable debugging mode and print an additional start and optional end marker (if the static CLI didn't exit before) to indicate that the static CLI ran. Defaults to `False`. |
+| `converters` | `Dict[Type, Callable[[str], Any]]` | Dict mapping types to global converter functions that will be used to deserialize types.                                                                                     |
 
 #### <kbd>method</kbd> `StaticRadicli.__init__`
 
@@ -582,12 +582,12 @@ data = cli.to_static_json()
 static = StaticRadicli(data)
 ```
 
-| Argument           | Type                 | Description                                                                                                                                                                                                      |
-| ------------------ | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `data`             | `Dict[str, Any]`     | The static data.                                                                                                                                                                                                 |
-| `disable`          | `bool`               | Whether to disable static parsing. Can be useful during development. Defaults to `False`.                                                                                                                        |
-| `debug`            | `bool`               | Enable debugging mode and print an additional start and optional end marker (if the static CLI didn't exit before) to indicate that the static CLI ran. Defaults to `False`.                                     |
-| `deserialize_type` | `Optional[Callable]` | Optional callback to deserialize custom argument types. Is called on unknown types and will receive the string name of the type, e.g. `"UUID"`, and should return a callable type, converter function or `None`. |
+| Argument     | Type                               | Description                                                                                                                                                                  |
+| ------------ | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `data`       | `Dict[str, Any]`                   | The static data.                                                                                                                                                             |
+| `disable`    | `bool`                             | Whether to disable static parsing. Can be useful during development. Defaults to `False`.                                                                                    |
+| `debug`      | `bool`                             | Enable debugging mode and print an additional start and optional end marker (if the static CLI didn't exit before) to indicate that the static CLI ran. Defaults to `False`. |
+| `converters` | `Dict[Type, Callable[[str], Any]]` | Dict mapping types to global converter functions that will be used to deserialize types.                                                                                     |
 
 #### <kbd>method</kbd> `StaticRadicli.run`
 

--- a/radicli/cli.py
+++ b/radicli/cli.py
@@ -12,7 +12,7 @@ from .util import Arg, ArgparseArg, get_arg, join_strings, format_type, format_t
 from .util import format_arg_help, expand_error_subclasses, SimpleFrozenDict
 from .util import CommandNotFoundError, CliParserError, CommandExistsError
 from .util import ConverterType, ConvertersType, ErrorHandlersType, StaticCommand
-from .util import StaticData, DeserializeType, DEFAULT_CONVERTERS, DEFAULT_PLACEHOLDER
+from .util import StaticData, DEFAULT_CONVERTERS, DEFAULT_PLACEHOLDER
 
 
 _CallableT = TypeVar("_CallableT", bound=Callable)
@@ -48,15 +48,14 @@ class Command:
     def from_static_json(
         cls,
         data: StaticCommand,
-        deserialize_type: Optional[DeserializeType] = None,
+        converters: ConvertersType = SimpleFrozenDict(),
     ) -> "Command":
         """Initialize the static command from a JSON-serializable dict."""
         return cls(
             name=data["name"],
             func=lambda *args, **kwargs: None,  # dummy function for static use
             args=[
-                ArgparseArg.from_static_json(arg, deserialize_type=deserialize_type)
-                for arg in data["args"]
+                ArgparseArg.from_static_json(arg, converters) for arg in data["args"]
             ],
             description=data["description"],
             allow_extra=data["allow_extra"],

--- a/radicli/cli.py
+++ b/radicli/cli.py
@@ -12,7 +12,7 @@ from .util import Arg, ArgparseArg, get_arg, join_strings, format_type, format_t
 from .util import format_arg_help, expand_error_subclasses, SimpleFrozenDict
 from .util import CommandNotFoundError, CliParserError, CommandExistsError
 from .util import ConverterType, ConvertersType, ErrorHandlersType, StaticCommand
-from .util import StaticData, DEFAULT_CONVERTERS, DEFAULT_PLACEHOLDER
+from .util import StaticData, DeserializeType, DEFAULT_CONVERTERS, DEFAULT_PLACEHOLDER
 
 
 _CallableT = TypeVar("_CallableT", bound=Callable)
@@ -45,12 +45,19 @@ class Command:
         }
 
     @classmethod
-    def from_static_json(cls, data: StaticCommand) -> "Command":
+    def from_static_json(
+        cls,
+        data: StaticCommand,
+        deserialize_type: Optional[DeserializeType] = None,
+    ) -> "Command":
         """Initialize the static command from a JSON-serializable dict."""
         return cls(
             name=data["name"],
             func=lambda *args, **kwargs: None,  # dummy function for static use
-            args=[ArgparseArg.from_static_json(arg) for arg in data["args"]],
+            args=[
+                ArgparseArg.from_static_json(arg, deserialize_type=deserialize_type)
+                for arg in data["args"]
+            ],
             description=data["description"],
             allow_extra=data["allow_extra"],
             parent=data["parent"],

--- a/radicli/static.py
+++ b/radicli/static.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import json
 
 from .cli import Radicli, Command
-from .util import StaticData, DeserializeType
+from .util import StaticData, ConvertersType, SimpleFrozenDict
 
 
 class StaticRadicli(Radicli):
@@ -16,7 +16,7 @@ class StaticRadicli(Radicli):
         data: StaticData,
         disable: bool = False,
         debug: bool = False,
-        deserialize_type: Optional[DeserializeType] = None,
+        converters: ConvertersType = SimpleFrozenDict(),
     ) -> None:
         super().__init__(
             prog=data["prog"],
@@ -25,12 +25,12 @@ class StaticRadicli(Radicli):
             extra_key=data["extra_key"],
         )
         self.commands = {
-            name: Command.from_static_json(cmd, deserialize_type=deserialize_type)
+            name: Command.from_static_json(cmd, converters)
             for name, cmd in data["commands"].items()
         }
         self.subcommands = {
             parent: {
-                name: Command.from_static_json(sub, deserialize_type=deserialize_type)
+                name: Command.from_static_json(sub, converters)
                 for name, sub in subs.items()
             }
             for parent, subs in data["subcommands"].items()
@@ -61,7 +61,7 @@ class StaticRadicli(Radicli):
         file_path: Union[str, Path],
         debug: bool = False,
         disable: bool = False,
-        deserialize_type: Optional[DeserializeType] = None,
+        converters: ConvertersType = SimpleFrozenDict(),
     ) -> "StaticRadicli":
         """Load the static CLI from a file path created with Radicli.to_static."""
         path = Path(file_path)
@@ -69,6 +69,4 @@ class StaticRadicli(Radicli):
             raise ValueError(f"Not a valid file path: {path}")
         with path.open("r", encoding="utf8") as f:
             data = json.load(f)
-        return cls(
-            data, disable=disable, debug=debug, deserialize_type=deserialize_type
-        )
+        return cls(data, disable=disable, debug=debug, converters=converters)

--- a/radicli/static.py
+++ b/radicli/static.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import json
 
 from .cli import Radicli, Command
-from .util import StaticData
+from .util import StaticData, DeserializeType
 
 
 class StaticRadicli(Radicli):
@@ -12,7 +12,11 @@ class StaticRadicli(Radicli):
     debug: bool
 
     def __init__(
-        self, data: StaticData, disable: bool = False, debug: bool = False
+        self,
+        data: StaticData,
+        disable: bool = False,
+        debug: bool = False,
+        deserialize_type: Optional[DeserializeType] = None,
     ) -> None:
         super().__init__(
             prog=data["prog"],
@@ -21,11 +25,14 @@ class StaticRadicli(Radicli):
             extra_key=data["extra_key"],
         )
         self.commands = {
-            name: Command.from_static_json(cmd)
+            name: Command.from_static_json(cmd, deserialize_type=deserialize_type)
             for name, cmd in data["commands"].items()
         }
         self.subcommands = {
-            parent: {name: Command.from_static_json(sub) for name, sub in subs.items()}
+            parent: {
+                name: Command.from_static_json(sub, deserialize_type=deserialize_type)
+                for name, sub in subs.items()
+            }
             for parent, subs in data["subcommands"].items()
         }
         self.data = data
@@ -50,7 +57,11 @@ class StaticRadicli(Radicli):
 
     @classmethod
     def load(
-        cls, file_path: Union[str, Path], debug: bool = False, disable: bool = False
+        cls,
+        file_path: Union[str, Path],
+        debug: bool = False,
+        disable: bool = False,
+        deserialize_type: Optional[DeserializeType] = None,
     ) -> "StaticRadicli":
         """Load the static CLI from a file path created with Radicli.to_static."""
         path = Path(file_path)
@@ -58,4 +69,6 @@ class StaticRadicli(Radicli):
             raise ValueError(f"Not a valid file path: {path}")
         with path.open("r", encoding="utf8") as f:
             data = json.load(f)
-        return cls(data, disable=disable, debug=debug)
+        return cls(
+            data, disable=disable, debug=debug, deserialize_type=deserialize_type
+        )

--- a/radicli/util.py
+++ b/radicli/util.py
@@ -1,5 +1,6 @@
 from typing import Any, Callable, Iterable, Type, Union, Optional, Dict, Tuple
-from typing import List, Literal, NewType, get_args, get_origin, TypeVar, TypedDict
+from typing import List, Literal, NewType, get_args, get_origin, TypeVar
+from typing import TypedDict, cast
 from enum import Enum
 from dataclasses import dataclass
 from pathlib import Path
@@ -351,7 +352,7 @@ def stringify_type(arg_type: Any) -> Optional[str]:
         if args:
             # Built-in generic types are callables in Python 3.10+ so we want to
             # preserve args here and stringify them, too
-            type_args = [stringify_type(arg) for arg in args]
+            type_args = cast(List[str], [stringify_type(arg) for arg in args])
             type_str = f"{type_str}[{', '.join(type_args)}]"
         return type_str
     type_str = str(arg_type)

--- a/radicli/util.py
+++ b/radicli/util.py
@@ -343,7 +343,9 @@ def stringify_type(arg_type: Any) -> Optional[str]:
     """Get a pretty-printed string for a type."""
     if isinstance(arg_type, str) or arg_type is None:
         return arg_type
-    if hasattr(arg_type, "__name__"):
+    # Only use name for callables because __name__ is internals and
+    # inconsistent for typing module
+    if callable(arg_type) and hasattr(arg_type, "__name__"):
         return arg_type.__name__
     type_str = str(arg_type)
     split_type = type_str.rsplit(".", 1)


### PR DESCRIPTION
This change stores string representations of the argument types with the static data allows loading arguments, commands or the whole CLI from static data while preserving the original types.

This can be useful if the CLI or a command needs to be reconstructed in a separate environment that doesn't have access to the original types and functions. For custom types with converters, a converters dict can be passed in in the same style as the converters passed to the non-static CLI.