### PR TITLE
Fix display type generation and formatting

### DIFF
--- a/radicli/cli.py
+++ b/radicli/cli.py
@@ -114,6 +114,7 @@ class Command:
                 default=sig_defaults[param],
                 skip_resolve=converter is not None,
                 get_converter=get_converter,
+                has_converter=converter is not None,
             )
             arg.help = join_strings(arg.help, f"({format_type(arg.display_type)})")
             cli_args.append(arg)

--- a/radicli/util.py
+++ b/radicli/util.py
@@ -249,6 +249,7 @@ def get_arg(
     orig_type: Union[ArgTypeType, str] = None,
     default: Optional[Any] = DEFAULT_PLACEHOLDER,
     get_converter: Optional[Callable[[Type], Optional[ConverterType]]] = None,
+    has_converter: bool = False,
     skip_resolve: bool = False,
 ) -> ArgparseArg:
     """Generate an argument to add to argparse and interpret types if possible."""
@@ -259,6 +260,7 @@ def get_arg(
         help=orig_arg.help,
         default=default,
         orig_type=orig_type,
+        has_converter=has_converter,
     )
     if orig_arg.count:
         arg.action = "count"
@@ -364,7 +366,8 @@ def format_type(arg_type: Any) -> Optional[str]:
     """Get a pretty-printed string for a type."""
     type_str = stringify_type(arg_type)
     if isinstance(arg_type, type(NewType)) and hasattr(arg_type, "__supertype__"):  # type: ignore
-        return f"{type_str} {arg_type.__name__}"  # type: ignore
+        supertype = stringify_type(arg_type.__supertype__)
+        return f"{type_str} ({supertype})"  # type: ignore
     return type_str
 
 

--- a/radicli/util.py
+++ b/radicli/util.py
@@ -365,9 +365,20 @@ def stringify_type(arg_type: Any) -> Optional[str]:
 def format_type(arg_type: Any) -> Optional[str]:
     """Get a pretty-printed string for a type."""
     type_str = stringify_type(arg_type)
-    if isinstance(arg_type, type(NewType)) and hasattr(arg_type, "__supertype__"):  # type: ignore
-        supertype = stringify_type(arg_type.__supertype__)
-        return f"{type_str} ({supertype})"  # type: ignore
+    # Hacky check for cross-platform supertypes for NewType custom types
+    if (
+        (
+            # Python < 3.10
+            hasattr(arg_type, "__qualname__")
+            and arg_type.__qualname__.startswith("NewType")
+        )
+        # Python 3.10+
+        or (hasattr(arg_type, "__class__") and arg_type.__class__ is NewType)
+    ) and (
+        hasattr(arg_type, "__supertype__")
+    ):  # type: ignore
+        supertype = stringify_type(arg_type.__supertype__)  # type: ignore
+        return f"{type_str} ({supertype})"
     return type_str
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 0.0.15
+version = 0.0.16
 description = Radically lightweight command-line interfaces
 url = https://github.com/explosion/radicli
 author = Explosion


### PR DESCRIPTION
`ArgparseArg.display_type` didn't end up returning the correct type because `has_converter` wasn't set consistently. Also fixes a formatting regression in `format_type`.