### PR TITLE
Add fill_defaults=False option

### DIFF
--- a/radicli/tests/test_cli.py
+++ b/radicli/tests/test_cli.py
@@ -953,3 +953,35 @@ def test_cli_arg_display_type(arg_type, expected_type, expected_str):
     arg = cmd.args[0]
     assert arg.display_type == expected_type
     assert format_type(arg.display_type) == expected_str
+
+
+def test_cli_no_defaults():
+    cli = Radicli(fill_defaults=False)
+    ran = False
+
+    @cli.command(
+        "test",
+        a=Arg(),
+        b=Arg(),
+        c=Arg("--c", "-C"),
+        d=Arg("--d", "-D"),
+        e=Arg("--e", "-E"),
+    )
+    def test(a: str, b: str = "1", *, c: int = 1, d: bool = False, e: str = "yo"):
+        assert a == "hello"
+        assert b == "1"
+        assert c == 3
+        assert d is True
+        assert e == "yo"
+        nonlocal ran
+        ran = True
+
+    args = ["hello", "--c", "3", "--d"]
+    parsed = cli.parse(args, cli.commands["test"])
+    assert parsed == {"a": "hello", "c": 3, "d": True}
+    cli.run(["", *args])
+    assert ran
+    # Make sure that set defaults are still preserved
+    args = ["hello", "--c", "1", "--d"]
+    parsed = cli.parse(args, cli.commands["test"])
+    assert parsed == {"a": "hello", "c": 1, "d": True}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 0.0.18
+version = 0.0.19
 description = Radically lightweight command-line interfaces
 url = https://github.com/explosion/radicli
 author = Explosion


### PR DESCRIPTION
Can be set when initializing `Radicli` and if set to `False`, `Radicli.parse` won't fill in any defaults and will only return the arguments set on the CLI. In the case of `Radicli.run`, only the CLI arguments will be passed to the function (which should essentially have the same effect as `fill_defaults=True`) Arguments will still be validated and errors are raised for missing required arguments.