### PR TITLE
Add --no- prefix in auto-generated docs

### DIFF
--- a/radicli/document.py
+++ b/radicli/document.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from pathlib import Path
 import re
 
-from .util import format_type, DEFAULT_PLACEHOLDER
+from .util import format_type, BooleanOptionalAction, DEFAULT_PLACEHOLDER
 
 if TYPE_CHECKING:
     from .cli import Radicli, Command
@@ -61,6 +61,9 @@ def _command(
         table = []
         for ap_arg in cmd.args:
             name = f"`{ap_arg.arg.option or ap_arg.id}`"
+            if ap_arg.action == BooleanOptionalAction and ap_arg.default is True:
+                assert ap_arg.arg.option
+                name += f"/`--no-{ap_arg.arg.option[2:]}`"
             if ap_arg.arg.short:
                 name += ", " + f"`{ap_arg.arg.short}`"
             default = ""

--- a/radicli/tests/test_document.py
+++ b/radicli/tests/test_document.py
@@ -46,12 +46,14 @@ def test_document_cli():
         "child",
         arg1=Arg(help="Argument one", converter=convert_my_custom_type),
         arg2=Arg(help="Argument two"),
+        arg3=Arg("--arg3", help="Argument three"),
     )
     def child2(
         arg1: MyCustomType,
         arg2: ExistingFilePath = cast(
             ExistingFilePath, Path(__file__).parent / "__init__.py"
         ),
+        arg3: bool = True,
     ):
         """This is command 3 and its child."""
 
@@ -107,4 +109,5 @@ This is command 3 and its child.
 | --- | --- | --- | --- |
 | `arg1` | `MyCustomType` | Argument one |  |
 | `arg2` | `ExistingFilePath (Path)` | Argument two | `__init__.py` |
+| `--arg3`/`--no-arg3` | `bool` | Argument three | `True` |
 """

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 0.0.22
+version = 0.0.23
 description = Radically lightweight command-line interfaces
 url = https://github.com/explosion/radicli
 author = Explosion


### PR DESCRIPTION
```
| Argument | Type | Description | Default |
| --- | --- | --- | --- |
| `arg1` | `MyCustomType` | Argument one |  |
| `arg2` | `ExistingFilePath (Path)` | Argument two | `__init__.py` |
| `--arg3`/`--no-arg3` | `bool` | Argument three | `True` |
```