### PR TITLE
handle types as strings

### DIFF
--- a/radicli/tests/test_util.py
+++ b/radicli/tests/test_util.py
@@ -5,7 +5,7 @@ import pathlib
 from uuid import UUID
 import pytest
 import shutil
-from radicli.util import stringify_type, get_list_converter
+from radicli.util import stringify_type, get_list_converter, get_arg, Arg
 
 _KindT = TypeVar("_KindT", bound=Union[str, int, float, Path])
 
@@ -61,3 +61,13 @@ def test_stringify_type(arg_type, expected):
 def test_get_list_converter(item_type, value, expected):
     converter = get_list_converter(item_type)
     assert converter(value) == expected
+
+def test_get_arg_string_type():
+    arg_info = Arg()
+    result = get_arg("test_param", arg_info, "str")
+    assert result.type is str
+
+def test_get_arg_regular_type():
+    arg_info = Arg()
+    result = get_arg("test_param", arg_info, int)
+    assert result.type is int

--- a/radicli/util.py
+++ b/radicli/util.py
@@ -296,6 +296,8 @@ def get_arg(
     skip_resolve: bool = False,
 ) -> ArgparseArg:
     """Generate an argument to add to argparse and interpret types if possible."""
+    if isinstance(param_type, str) and param_type in BASE_TYPES_MAP:
+        param_type = BASE_TYPES_MAP[param_type]
     arg = ArgparseArg(
         id=param,
         arg=orig_arg,


### PR DESCRIPTION
Based on this user [report](https://support.prodi.gy/t/bug-report-loading-custom-recipe-raises-unsupported-type-for-dataset-str/7606) there is an issue on Windows in that the the type hint is being passed as a string to `get_arg` function which cause "Unsupported type" error.

This PR adds handling of such stringified types.