### PR TITLE
Support | syntax for unions and optionals (Python 3.10+)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10']
+        python-version: ['3.10', '3.13']
     steps:
       - uses: actions/checkout@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,11 +21,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install
-        run: pip install -r requirements.txt
+        run: |
+          pip install -r requirements.txt
+          pip install build
       - name: Run pyright
         run: python -m pyright ${{ env.PACKAGE }}
       - name: Build sdist
-        run: python setup.py sdist
+        run: python -m build --sdist
       - name: Remove package directory
         run: rm -rf ${{ env.PACKAGE }}
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.10']
     steps:
       - uses: actions/checkout@v1
         with:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## ⏳ Installation
 
-Note that `radicli` currently requires **Python 3.8+**.
+Note that `radicli` currently requires **Python 3.10+**.
 
 ```bash
 pip install radicli

--- a/radicli/tests/test_cli.py
+++ b/radicli/tests/test_cli.py
@@ -1003,6 +1003,19 @@ def test_cli_no_defaults():
     assert parsed == {"a": "hello", "c": 1, "d": True}
 
 
+def test_cli_optional_syntax():
+    cli = Radicli()
+
+    @cli.command("test", a=Arg("--a"), b=Arg("--b"))
+    def test(a: str | None, b: Optional[str]):
+        ...
+
+    parsed = cli.parse(["--a", "hello"], cli.commands["test"])
+    assert parsed == {"a": "hello", "b": None}
+    parsed = cli.parse(["--b", "hello"], cli.commands["test"])
+    assert parsed == {"a": None, "b": "hello"}
+
+
 def test_cli_booleans():
     cli = Radicli()
 

--- a/radicli/tests/test_cli.py
+++ b/radicli/tests/test_cli.py
@@ -1013,13 +1013,22 @@ def test_cli_optional_syntax():
     cli = Radicli()
 
     @cli.command("test", a=Arg("--a"), b=Arg("--b"))
-    def test(a: str | None, b: Optional[str]):
-        ...
+    def test(a: str | None, b: Optional[str]): ...
 
     parsed = cli.parse(["--a", "hello"], cli.commands["test"])
     assert parsed == {"a": "hello", "b": None}
     parsed = cli.parse(["--b", "hello"], cli.commands["test"])
     assert parsed == {"a": None, "b": "hello"}
+
+
+def test_cli_pipe_syntax():
+    cli = Radicli()
+
+    @cli.command("test", a=Arg("--a"), b=Arg("--b"))
+    def test(a: float | int, b: Path | str): ...
+
+    parsed = cli.parse(["--a", "1", "--b", "/path"], cli.commands["test"])
+    assert parsed == {"a": 1.0, "b": Path("/path")}
 
 
 def test_cli_booleans():

--- a/radicli/util.py
+++ b/radicli/util.py
@@ -1,6 +1,7 @@
 from typing import Any, Callable, Iterable, Type, Union, Optional, Dict, Tuple
 from typing import List, Literal, NewType, get_args, get_origin, TypeVar
 from typing import TypedDict, cast
+from types import UnionType
 from enum import Enum
 from uuid import UUID
 from dataclasses import dataclass
@@ -328,7 +329,7 @@ def get_arg(
         return arg
     if skip_resolve:
         return arg
-    if origin is Union:
+    if origin in (Union, UnionType):  # UnionType is | syntax
         if type(None) in args and default is DEFAULT_PLACEHOLDER:
             default = None
         arg_types = [a for a in args if a != type(None)]  # noqa: E721

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 0.0.26
+version = 0.1.0
 description = Radically lightweight command-line interfaces
 url = https://github.com/explosion/radicli
 author = Explosion
@@ -17,16 +17,17 @@ classifiers =
     Operating System :: MacOS :: MacOS X
     Operating System :: Microsoft :: Windows
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Topic :: Scientific/Engineering
 
 [options]
 zip_safe = true
 include_package_data = true
-python_requires = >=3.8
+python_requires = >=3.10
 
 [sdist]
 formats = gztar


### PR DESCRIPTION
- Correctly support optionals via union, e.g. `str | None`
- Correctly support unions with `|` syntax, e.g. `float | int` (for conversion from CLI, the first type is currently used – this could potentially be improved)
- Require Python 3.10+ and update test matrix